### PR TITLE
force set recvbuf on linux with CAP_NET_ADMIN

### DIFF
--- a/conn_linux.go
+++ b/conn_linux.go
@@ -1,0 +1,32 @@
+//go:build linux
+// +build linux
+
+package quic
+
+import (
+	"errors"
+	"fmt"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+func setConnReadBufferForce(c interface{}, size int) error {
+	conn, ok := c.(interface {
+		SyscallConn() (syscall.RawConn, error)
+	})
+	if !ok {
+		return errors.New("doesn't have a SyscallConn")
+	}
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		return fmt.Errorf("couldn't get syscall.RawConn: %w", err)
+	}
+	var serr error
+	if err := rawConn.Control(func(fd uintptr) {
+		serr = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_RCVBUFFORCE, size)
+	}); err != nil {
+		return err
+	}
+	return serr
+}

--- a/conn_nonlinux.go
+++ b/conn_nonlinux.go
@@ -1,0 +1,10 @@
+//go:build !linux
+// +build !linux
+
+package quic
+
+import "errors"
+
+func setConnReadBufferForce(c interface{}, size int) error {
+	return errors.New("Unsupported on this platform")
+}

--- a/packet_handler_map.go
+++ b/packet_handler_map.go
@@ -93,7 +93,7 @@ func setReceiveBuffer(c net.PacketConn, logger utils.Logger) error {
 	if size >= protocol.DesiredReceiveBufferSize {
 		logger.Debugf("Conn has receive buffer of %d kiB (wanted: at least %d kiB)", size/1024, protocol.DesiredReceiveBufferSize/1024)
 	}
-	if err := conn.SetReadBuffer(protocol.DesiredReceiveBufferSize); err != nil {
+	if err := setConnReadBuffer(conn, protocol.DesiredReceiveBufferSize); err != nil {
 		return fmt.Errorf("failed to increase receive buffer size: %w", err)
 	}
 	newSize, err := inspectReadBuffer(c)
@@ -107,6 +107,15 @@ func setReceiveBuffer(c net.PacketConn, logger utils.Logger) error {
 		return fmt.Errorf("failed to sufficiently increase receive buffer size (was: %d kiB, wanted: %d kiB, got: %d kiB)", size/1024, protocol.DesiredReceiveBufferSize/1024, newSize/1024)
 	}
 	logger.Debugf("Increased receive buffer size to %d kiB", newSize/1024)
+	return nil
+}
+
+func setConnReadBuffer(conn interface{ SetReadBuffer(int) error }, size int) error {
+	if ferr := setConnReadBufferForce(conn, size); ferr != nil {
+		if err := conn.SetReadBuffer(size); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
This reduces messages like
```
2022/02/12 12:27:37 failed to sufficiently increase receive buffer size (was: 208 kiB, wanted: 2048 kiB, got: 416 kiB). See https://github.com/lucas-clemente/quic-go/wiki/UDP-Receive-Buffer-Size for details.
```

And we should also add CAP_NET_ADMIN into systemd unit of hysteria.