### PR TITLE
don't treat setDF failed as error

### DIFF
--- a/sys_conn_df_bsd.go
+++ b/sys_conn_df_bsd.go
@@ -27,7 +27,7 @@ func setDF(rawConn syscall.RawConn) error {
 	case errDFIPv4 != nil && errDFIPv6 == nil:
 		utils.DefaultLogger.Debugf("Setting DF for IPv6.")
 	case errDFIPv4 != nil && errDFIPv6 != nil:
-		return errors.New("setting DF failed for both IPv4 and IPv6")
+		utils.DefaultLogger.Errorf("setting DF failed for both IPv4 and IPv6: errDFIPv4=%s, errDFIPv6=%s", errDFIPv4.Error(), errDFIPv6.Error())
 	}
 	return nil
 }

--- a/sys_conn_df_linux.go
+++ b/sys_conn_df_linux.go
@@ -27,7 +27,7 @@ func setDF(rawConn syscall.RawConn) error {
 	case errDFIPv4 != nil && errDFIPv6 == nil:
 		utils.DefaultLogger.Debugf("Setting DF for IPv6.")
 	case errDFIPv4 != nil && errDFIPv6 != nil:
-		return errors.New("setting DF failed for both IPv4 and IPv6")
+		utils.DefaultLogger.Errorf("setting DF failed for both IPv4 and IPv6: errDFIPv4=%s, errDFIPv6=%s", errDFIPv4.Error(), errDFIPv6.Error())
 	}
 	return nil
 }

--- a/sys_conn_df_windows.go
+++ b/sys_conn_df_windows.go
@@ -44,7 +44,7 @@ func setDF(rawConn syscall.RawConn) error {
 	case errDFIPv4 != nil && errDFIPv6 == nil:
 		utils.DefaultLogger.Debugf("Setting DF for IPv6.")
 	case errDFIPv4 != nil && errDFIPv6 != nil:
-		return errors.New("setting DF failed for both IPv4 and IPv6")
+		utils.DefaultLogger.Errorf("setting DF failed for both IPv4 and IPv6: errDFIPv4=%s, errDFIPv6=%s", errDFIPv4.Error(), errDFIPv6.Error())
 	}
 	return nil
 }


### PR DESCRIPTION
`setDF()` raised this error and made hysteria fully stop working on Windows 7
https://github.com/HyNetwork/hysteria/issues/327

I tested and seems like ignoring this error won't cause other problems.

And this error handle itself is really weird:
+ IPv4 setDF failed => ok
+ IPv6 setDF failed => ok
+ IPv4 setDF failed && IPv6 setDF failed => raise err (why?)