### PR TITLE
fix: Modify UDP GSO request logic for payload segmentation

### DIFF
--- a/sys_conn_oob.go
+++ b/sys_conn_oob.go
@@ -250,7 +250,13 @@ func (c *oobConn) WritePacket(b []byte, addr net.Addr, packetInfoOOB []byte, gso
 		if !c.capabilities().GSO {
 			panic("GSO disabled")
 		}
-		oob = appendUDPSegmentSizeMsg(oob, gsoSize)
+		// Only request UDP GSO when the payload will actually be segmented.
+		// Some drivers/devices misbehave when UDP_SEGMENT is set for an effectively
+		// single-segment send (segment_size >= payload length). This mirrors quinn-udp's
+		// behavior.
+		if len(b) > int(gsoSize) {
+			oob = appendUDPSegmentSizeMsg(oob, gsoSize)
+		}
 	}
 	if ecn != protocol.ECNUnsupported {
 		if !c.capabilities().ECN {


### PR DESCRIPTION
## Summary

This patch is intended to fix (or bypass) the broken UDP GSO support issue mentioned in apernet/hysteria#1233, openwrt/openwrt#17855, and immortalwrt/packages#1476. Maybe the patch should be sent to the upstream [quic-go](https://github.com/quic-go/quic-go) repo, but I prefer to send it here first since some hysteria users running OpenWRT with PPPoE have been affected by this issue.

## Problem Statement

When investigating the root cause of the broken UDP GSO support problem, I noticed that [quinn-rs/quinn](https://github.com/quinn-rs/quinn) doesn't seem to be affected by the related issue: I wrote a client-side PoC which is compatible with hysteria's speedtest API in Rust and quinn, and the Rust variant PoC did not reproduce the drained connection/packet loss problem observed with hysteria+GSO. Therefore, I did a quick comparison between quinn's and quic-go's implementation for UDP GSO. The key difference is listed below:

- quic-go attaches `UDP_SEGMENT` whenever `gsoSize > 0`. `UDP_SEGMENT` cmsg is always appended when `gsoSize > 0` in `quic-go/sys_conn_oob.go`

- quinn-udp explicitly avoids setting `UDP_SEGMENT` unless it will actually segment. In `quinn-udp/src/unix.rs`, quinn-udp only sets `UDP_SEGMENT` if `segment_size < transmit.contents.len()` (multi-segment).

If the PPPoE device path (or its underlying driver feature propagation) mishandles **the presence of `UDP_SEGMENT` when there’s effectively only one segment** (`segment_size >= payload_len`), quic-go will hit that case frequently (ACK-only / control packets after handshake confirmation), causing ACK loss and a rapid throughput collapse (“connection drains quickly”). quinn-udp avoids that exact case by design, so it would keep sending those small packets normally.

## Patch Description
```diff
 func (c *oobConn) WritePacket(b []byte, addr net.Addr, packetInfoOOB []byte, gsoSize uint16, ecn protocol.ECN) (int, error) {
 	oob := packetInfoOOB
 	if gsoSize > 0 {
 		if !c.capabilities().GSO {
 			panic("GSO disabled")
 		}
-		oob = appendUDPSegmentSizeMsg(oob, gsoSize)
+		// Only request UDP GSO when the payload will actually be segmented.
+		// Some drivers/devices misbehave when UDP_SEGMENT is set for an effectively
+		// single-segment send (segment_size >= payload length). This mirrors quinn-udp's
+		// Linux behavior.
+		if len(b) > int(gsoSize) {
+			oob = appendUDPSegmentSizeMsg(oob, gsoSize)
+		}
 	}
...
```
Add condition to request UDP GSO only for segmented payloads to prevent issues with certain drivers like PPPoE. The patch works on my platform. @kousyougi @wherss1 @NogKCcn Please help test whether this patch works for you as well. cc @LGA1150 @dyhkwong @nekohasekai